### PR TITLE
Remove leading lines

### DIFF
--- a/src/Constant/SystemPaymentMethod.php
+++ b/src/Constant/SystemPaymentMethod.php
@@ -1,5 +1,3 @@
-
-
 <?php
 
 /**
@@ -52,5 +50,3 @@ abstract class SystemPaymentMethod {
     const PAYMENTPLAN_NL = 'SVEASPLITEU_NL';
 
 }
-
-?>


### PR DESCRIPTION
Empty lines before `<?php` are outputted and are throwing errors on several CMSs. Also it's a good practice to omit the ending `?>` -- this assures that you won't left some spaces/newlines at the end. `?>` is not mandatory.
