### PR TITLE
Add "simulatorcode" capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ $form = WebPay::createOrder()
             ->setPayPageLanguage("sv")                          //Optional, default english
             ->setReturnUrl("http://myurl.se")                   //Required
             ->setCancelUrl("http://myurl.se")                   //Optional
+            ->setSimulatorCode(107)				// Optional. Force SveaWebPay to return the error code 107 (only in testing mode)
                 ->getPaymentForm();
 
 ```

--- a/src/HostedRequests/Helper/HostedXmlBuilder.php
+++ b/src/HostedRequests/Helper/HostedXmlBuilder.php
@@ -27,6 +27,7 @@ class HostedXmlBuilder {
         $this->XMLWriter->writeElement("amount", $request['amount']);
         $this->XMLWriter->writeElement("currency", $request['currency']);
         $this->XMLWriter->writeElement("lang", $request['langCode']);
+        $this->XMLWriter->writeElement("simulatorcode", $request['simulatorCode']);        
         if ($request['totalVat'] != null) {
             $this->XMLWriter->writeElement("vat", $request['totalVat']);
         }

--- a/src/HostedRequests/Payment/HostedPayment.php
+++ b/src/HostedRequests/Payment/HostedPayment.php
@@ -19,6 +19,7 @@ class HostedPayment {
     public $returnUrl;
     public $cancelUrl;
     public $langCode;
+    public $simulatorCode;
 
     /**
      * @param type $order
@@ -78,13 +79,22 @@ class HostedPayment {
         $request['returnUrl'] = $this->returnUrl;
         $request['cancelUrl'] = $this->cancelUrl;
         $request['langCode'] = $this->langCode;
+        $request['simulatorCode'] = $this->simulatorCode;
         $currency = trim($this->order->currency);
         $currency = strtoupper($currency);
         $request['currency'] = $currency;
         return $this->configureExcludedPaymentMethods($request); //Method in child class
     }
     
-    
+    /**
+     * 
+     * @param type $simulatorCode
+     * @return \HostedPayment
+     */
+    public function setSimulatorCode($simulatorCode) {
+        $this->simulatorCode = $simulatorCode;
+        return $this;
+    } 
 }
 
 ?>


### PR DESCRIPTION
With this pull request, developers can test/simulate various returning codes for HostedPayment.
