### PR TITLE
Fixes empty submitMessage and noScriptMessage in PaymentForm.php

### DIFF
--- a/src/HostedService/Helper/PaymentForm.php
+++ b/src/HostedService/Helper/PaymentForm.php
@@ -42,11 +42,11 @@ class PaymentForm {
         $this->secretWord = $config->getSecret(\ConfigurationProvider::HOSTED_TYPE, $countryCode);
         $this->mac = hash("sha512", $this->xmlMessageBase64 . $this->secretWord);
         
+        $this->setSubmitMessage();
+                
         $this->setForm();
         $this->setHtmlFields();
         $this->setRawFields();        
-        
-        $this->setSubmitMessage();
     }
 
     public function setRawFields() {


### PR DESCRIPTION
Simply moves ```$this->setSubmitMessage()``` call in PaymentForm class constructor above ```$this->setForm()``` and ```$this->setHtmlFields()```, so ```$this->submitMessage``` and ```$this->noScriptMessage``` variables are available in ```setForm()``` and ```setHtmlFields()``` functions.